### PR TITLE
Update SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "firefly-rust"
-version = "0.11.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ade588d4b9fdf8b177e44274b8e083bc4b196f6711e783bb74b0b452a8ad072"
+checksum = "c99a781c0a6e84cdf93cc10c8633fb6d1b064a56ff145326aa1ec97796b696a4"
 dependencies = [
  "talc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.0"
 edition = "2024"
 
 [dependencies]
-firefly-rust = { version = "0.11.0", features = ["alloc", "talc"] }
+firefly-rust = { version = "0.13.2", features = ["alloc", "talc"] }
 
 # https://github.com/johnthagen/min-sized-rust
 [profile.release]

--- a/src/rendering.rs
+++ b/src/rendering.rs
@@ -1,5 +1,5 @@
 use alloc::format;
-use firefly_rust::{clear_screen, Color, Point};
+use firefly_rust::{Color, Point, clear_screen};
 
 use crate::{constants::*, drawing::*, palette::*, point_math::*, state::*};
 
@@ -25,8 +25,9 @@ pub fn render_ui() {
     state
         .players
         .iter()
-        .find(|player| Some(player.peer) == state.me)
-        .map(|player| {
+        .find(|player| player.peer == state.me)
+        .iter()
+        .for_each(|player| {
             let text = format!("Points:{}", player.points);
             display_large_text_color(text.as_str(), Point::new(0, 14), Palette::Black.into());
             display_large_text_color(

--- a/src/state.rs
+++ b/src/state.rs
@@ -19,7 +19,7 @@ pub struct State {
     pub font_large: FileBuf,
     pub font_small: FileBuf,
     pub game_state: GameState,
-    pub me: Option<Peer>,
+    pub me: Me,
     particles: ParticleSystem,
     pub players: Vec<Player>,
     pub spritesheet: FileBuf,
@@ -38,7 +38,7 @@ impl Default for State {
             font_large: load_file_buf("font_large").unwrap(),
             font_small: load_file_buf("font_small").unwrap(),
             game_state: GameState::Title,
-            me: None,
+            me: get_me(),
             particles: ParticleSystem::new(200),
             players: Vec::new(),
             spritesheet: load_file_buf("spritesheet").unwrap(),
@@ -57,11 +57,11 @@ pub fn get_state() -> &'static mut State {
 impl State {
     const WIN_POINTS: i32 = 20;
 
-    pub fn new(player: Peer, peers: Peers) -> Self {
+    pub fn new(me: Me, peers: Peers) -> Self {
         let world = World::new_from_2d_array(TILE_ARRAY);
         State {
             players: peers.iter().map(|peer| Player::new(peer, &world)).collect(),
-            me: Some(player),
+            me,
             world,
             ..State::default()
         }
@@ -126,7 +126,7 @@ impl State {
 
     pub fn add_points(&mut self, points: i32) -> i32 {
         for player in self.players.iter_mut() {
-            if self.me == Some(player.peer) {
+            if self.me == player.peer {
                 player.points += points;
                 return player.points;
             }
@@ -137,7 +137,7 @@ impl State {
     fn update_playing(&mut self) {
         for player in self.players.iter_mut() {
             player.update(&self.world);
-            if self.me == Some(player.peer) {
+            if self.me == player.peer {
                 self.camera.follow_player(player.position, 0.2);
             }
         }
@@ -166,7 +166,7 @@ impl State {
             .find(|player| player.points >= Self::WIN_POINTS)
         {
             add_progress(winner.peer, BADGE_WINS, 1);
-            self.game_state = GameState::GameOver(Some(winner.peer) == self.me);
+            self.game_state = GameState::GameOver(winner.peer == self.me);
         }
     }
 


### PR DESCRIPTION
The upcoming (hopefully this weekend) Firefly Zero release drops support for the old image format. To make sure Lampy still works when installed from the catalog, you need to re-build it with the latest CLI version and publish it.